### PR TITLE
feat: add automated tender response generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,24 @@ python extract_required_documents.py
 
 本项目采用MIT许可证，详见LICENSE文件。
 
+
+## 自动生成响应文件与附件
+
+本仓库新增 `main.py` 等模块，可根据分析表与招标文件自动生成响应附件和逐条说明。
+
+### 使用方法
+
+```bash
+export DASHSCOPE_API_KEY=your_key
+export QWEN_MODEL=qwen-plus
+python main.py --analysis /path/analysis.txt --tender /path/tender.pdf --repo /path/repo --out ./output
+```
+
+### 输出目录
+
+- `attachments/`：自动生成的附件模板
+- `responses/`：针对每条要求的响应文件
+- `manifest.json`：生成过程的元数据
+- `logs/`：关键日志
+
+所有文本理解与生成均通过通义千问API完成，本地代码仅负责I/O与调度。

--- a/analysis_parser.py
+++ b/analysis_parser.py
@@ -1,0 +1,24 @@
+"""Parse the analysis table using the LLM."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from llm_client import LLMClient
+
+ANALYSIS_PROMPT = (
+    "你是一名投标分析助手。请将以下分析表文本解析成 JSON。" \
+    "返回 schema 如下：" \
+    "{""requirements"": [{""id"": "", ""title"": "", ""type"": "", ""page"": "", ""importance"": "", ""score_current"": "", ""scoring_rule"": "", ""strengths"": [], ""weaknesses"": [], ""advice"": [], ""evidence_files"": []}], ""notes"": ""}"""
+)
+
+
+def parse_analysis(path: str | Path, llm: LLMClient) -> Dict:
+    """Send the entire analysis table to the LLM and parse it into JSON."""
+    text = Path(path).read_text(encoding="utf-8")
+    messages = [
+        {"role": "system", "content": ANALYSIS_PROMPT},
+        {"role": "user", "content": text},
+    ]
+    return llm.chat_json(messages)

--- a/attachment_generator.py
+++ b/attachment_generator.py
@@ -1,0 +1,47 @@
+"""Generate attachments according to the tender requirements."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from llm_client import LLMClient
+from utils import ensure_dir, write_text
+
+ATTACHMENT_PROMPT = (
+    "你是一名投标附件生成器。根据给定的附件规范、分析表摘要和参考资料，"\
+    "生成符合要求的 Markdown 内容。保持字段顺序，并在需要签章/签字的地方标注。"\
+    "输出 JSON {""content"": str, ""source_refs"": [], ""placeholders"": []}."
+)
+
+CHECK_PROMPT = (
+    "请根据附件规范检查以下内容是否满足所有字段、版式和约束要求。"\
+    "若有缺失，返回修订后的完整内容；若合格，原样返回。"
+)
+
+
+def generate_attachment(spec: Dict, analysis: Dict, evidence: Dict[str, str],
+                        llm: LLMClient, out_dir: Path) -> Path:
+    """Generate a single attachment file and return its path."""
+    messages = [
+        {"role": "system", "content": ATTACHMENT_PROMPT},
+        {"role": "user", "content": json.dumps({
+            "spec": spec,
+            "analysis_summary": analysis.get("notes", ""),
+            "evidence": evidence,
+        }, ensure_ascii=False)},
+    ]
+    result = llm.chat_json(messages)
+    content = result.get("content", "")
+
+    check_messages = [
+        {"role": "system", "content": CHECK_PROMPT},
+        {"role": "user", "content": json.dumps({"spec": spec, "draft": content}, ensure_ascii=False)},
+    ]
+    checked = llm.chat_json(check_messages).get("content", content)
+
+    filename = f"{spec['name'].replace(' ', '_')}.md"
+    out_path = out_dir / filename
+    ensure_dir(out_path.parent)
+    write_text(out_path, checked)
+    return out_path

--- a/chapter_extractor.py
+++ b/chapter_extractor.py
@@ -1,0 +1,20 @@
+"""Extract the '响应文件格式及附件' chapter from the tender document."""
+from __future__ import annotations
+
+from typing import Dict
+
+from llm_client import LLMClient
+
+CHAPTER_PROMPT = (
+    "你是一名投标文件解析助手。给定招标文件全文，找出标题为“响应文件格式及附件”的章节，"\
+    "返回 JSON: {""chapter_title"": str, ""start_index"": int, ""end_index"": int, ""raw_text"": str, ""attachments_spec"": []}."\
+    "attachments_spec 每项包含 name, required_format, fields, layout_notes, filetype, constraints。"
+)
+
+
+def extract_chapter(tender_text: str, llm: LLMClient) -> Dict:
+    messages = [
+        {"role": "system", "content": CHAPTER_PROMPT},
+        {"role": "user", "content": tender_text},
+    ]
+    return llm.chat_json(messages)

--- a/doc_loader.py
+++ b/doc_loader.py
@@ -1,0 +1,40 @@
+"""Utilities for loading different document formats as plain text."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import fitz  # PyMuPDF
+from docx import Document
+
+
+def load_pdf(path: Path) -> str:
+    """Load text from a PDF using PyMuPDF."""
+    doc = fitz.open(path)
+    texts = [page.get_text("text") for page in doc]
+    doc.close()
+    return "\n".join(texts)
+
+
+def load_docx(path: Path) -> str:
+    """Load text from a DOCX file."""
+    document = Document(path)
+    return "\n".join(p.text for p in document.paragraphs)
+
+
+def load_text(path: Path) -> str:
+    """Load text from a UTF-8 plain text/markdown file."""
+    return path.read_text(encoding="utf-8")
+
+
+def load_document(path: str | Path) -> str:
+    """Dispatch to the appropriate loader based on suffix."""
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".pdf":
+        return load_pdf(p)
+    if suffix in {".docx", ".doc"}:
+        return load_docx(p)
+    if suffix in {".md", ".txt"}:
+        return load_text(p)
+    raise ValueError(f"Unsupported file type: {suffix}")

--- a/file_search.py
+++ b/file_search.py
@@ -1,0 +1,28 @@
+"""Search and read evidence files from a repository."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from doc_loader import load_document
+
+
+def search_files(root: str | Path, patterns: Iterable[str]) -> List[Path]:
+    """Return a list of paths under ``root`` matching glob ``patterns``."""
+    root_path = Path(root)
+    matches: List[Path] = []
+    for pattern in patterns:
+        matches.extend(root_path.glob(pattern))
+    return [p for p in matches if p.is_file()]
+
+
+def read_files(paths: Iterable[str | Path]) -> Dict[str, str]:
+    """Read multiple documents and return mapping from path to text."""
+    contents: Dict[str, str] = {}
+    for p in paths:
+        path = Path(p)
+        try:
+            contents[str(path)] = load_document(path)
+        except Exception:
+            continue
+    return contents

--- a/llm_client.py
+++ b/llm_client.py
@@ -1,0 +1,75 @@
+"""LLM client for DashScope/通义千问.
+
+This module wraps the DashScope SDK to provide a simple chat interface with
+retry and rate limiting. All text understanding and generation tasks in this
+project rely on this client so that we do not use any local heuristics or
+regular expressions for semantic work.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+import time
+from typing import Dict, List, Optional
+
+import dashscope
+
+
+def _hash_messages(messages: List[Dict[str, str]]) -> str:
+    """Return a short hash of messages for logging/manifest."""
+    m = hashlib.sha256()
+    for msg in messages:
+        m.update(json.dumps(msg, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+    return m.hexdigest()[:10]
+
+
+@dataclass
+class LLMClient:
+    """Simple wrapper around DashScope's ChatCompletion API."""
+
+    model: Optional[str] = None
+    api_key: Optional[str] = None
+    max_retries: int = 3
+    temperature: float = 0.2
+    max_tokens: int = 4000
+
+    def __post_init__(self) -> None:
+        if self.api_key is None:
+            self.api_key = os.getenv("DASHSCOPE_API_KEY")
+        if self.model is None:
+            self.model = os.getenv("QWEN_MODEL", "qwen-plus")
+        dashscope.api_key = self.api_key
+
+    def chat(self, messages: List[Dict[str, str]], *,
+             temperature: Optional[float] = None,
+             max_tokens: Optional[int] = None) -> str:
+        """Send chat messages to the model and return the response text."""
+        temperature = temperature if temperature is not None else self.temperature
+        max_tokens = max_tokens if max_tokens is not None else self.max_tokens
+        attempt = 0
+        while True:
+            try:
+                response = dashscope.Generation.call(
+                    model=self.model,
+                    input={"messages": messages},
+                    parameters={"temperature": temperature, "max_tokens": max_tokens},
+                )
+                return response['output']['text']
+            except Exception as exc:  # pragma: no cover - network errors
+                attempt += 1
+                if attempt >= self.max_retries:
+                    raise
+                time.sleep(2 ** attempt)
+
+    def chat_json(self, messages: List[Dict[str, str]], *,
+                  temperature: Optional[float] = None,
+                  max_tokens: Optional[int] = None) -> Dict:
+        """Call :py:meth:`chat` and parse the result as JSON."""
+        text = self.chat(messages, temperature=temperature, max_tokens=max_tokens)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            # Surface the raw text to help debugging.
+            raise ValueError(f"LLM output is not valid JSON: {text}") from exc

--- a/main.py
+++ b/main.py
@@ -1,0 +1,66 @@
+"""CLI entry point for automatic tender response generation."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from analysis_parser import parse_analysis
+from attachment_generator import generate_attachment
+from chapter_extractor import extract_chapter
+from doc_loader import load_document
+from file_search import read_files, search_files
+from llm_client import LLMClient
+from response_writer import write_response
+from utils import dump_json, ensure_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="自动生成投标响应文件")
+    parser.add_argument("--analysis", required=True, help="分析表 TXT")
+    parser.add_argument("--tender", required=True, help="标书全文文件")
+    parser.add_argument("--repo", required=True, help="资料库根目录")
+    parser.add_argument("--out", default="./output", help="输出目录")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    attachments_dir = out_dir / "attachments"
+    responses_dir = out_dir / "responses"
+    logs_dir = out_dir / "logs"
+
+    ensure_dir(attachments_dir)
+    ensure_dir(responses_dir)
+    ensure_dir(logs_dir)
+
+    llm = LLMClient()
+
+    print("解析分析表...")
+    analysis = parse_analysis(args.analysis, llm)
+
+    print("读取标书...")
+    tender_text = load_document(args.tender)
+
+    print("抽取响应文件格式及附件章节...")
+    chapter = extract_chapter(tender_text, llm)
+
+    manifest: Dict[str, List[str]] = {"attachments": [], "responses": []}
+
+    print("生成附件...")
+    evidence_files = search_files(args.repo, ["**/*.md", "**/*.txt", "**/*.docx", "**/*.pdf"])
+    evidence_texts = read_files(evidence_files)
+    for spec in chapter.get("attachments_spec", []):
+        path = generate_attachment(spec, analysis, evidence_texts, llm, attachments_dir)
+        manifest["attachments"].append(str(path))
+
+    print("生成逐条响应...")
+    for req in analysis.get("requirements", []):
+        path = write_response(req, evidence_texts, llm, responses_dir)
+        manifest["responses"].append(str(path))
+
+    dump_json(out_dir / "manifest.json", {"chapter": chapter, **manifest})
+    print("完成。输出目录:", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pdfplumber==0.10.3
 requests==2.31.0
 PyMuPDF==1.23.8
-
+python-docx==0.8.11
+dashscope==1.14.1
+python-dotenv==1.0.1

--- a/response_writer.py
+++ b/response_writer.py
@@ -1,0 +1,29 @@
+"""Generate requirement-by-requirement response files."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from llm_client import LLMClient
+from utils import ensure_dir, write_text
+
+RESPONSE_PROMPT = (
+    "你是一名投标响应编写专家。根据给定的单条要求、可用证据文本，"\
+    "生成针对性的响应说明。使用 Markdown 并包含脚注引用。"\
+    "输出字段：title, content, source_refs, missing_items。"
+)
+
+
+def write_response(req: Dict, evidence: Dict[str, str], llm: LLMClient,
+                   out_dir: Path) -> Path:
+    messages = [
+        {"role": "system", "content": RESPONSE_PROMPT},
+        {"role": "user", "content": json.dumps({"requirement": req, "evidence": evidence}, ensure_ascii=False)},
+    ]
+    result = llm.chat_json(messages)
+    filename = f"要求_{req['id']}.md"
+    out_path = out_dir / filename
+    ensure_dir(out_path.parent)
+    write_text(out_path, result.get("content", ""))
+    return out_path

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,31 @@
+"""Miscellaneous utility helpers."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def ensure_dir(path: Path) -> None:
+    """Ensure parent directory exists."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text to ``path``."""
+    ensure_dir(path)
+    path.write_text(text, encoding="utf-8")
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump_json(path: Path, data: Any) -> None:
+    ensure_dir(path)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- add DashScope LLM client and document loaders
- parse analysis table and extract attachment chapter via Qwen
- generate attachments and responses through new CLI `main.py`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d59c95bd4832a9fc35e54fa84f2f8