### PR TITLE
feat: cycle through qwen models with rate limiting

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -7,7 +7,7 @@ regular expressions for semantic work.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import json
 import os
@@ -27,20 +27,47 @@ def _hash_messages(messages: List[Dict[str, str]]) -> str:
 
 @dataclass
 class LLMClient:
-    """Simple wrapper around DashScope's ChatCompletion API."""
+    """Simple wrapper around DashScope's ChatCompletion API.
 
-    model: Optional[str] = None
+    The client cycles through a predefined list of models. After every two
+    requests it waits one second. If the API returns a 400 status code the
+    client automatically switches to the next model in the list.
+    """
+
+    models: Optional[List[str]] = None
     api_key: Optional[str] = None
     max_retries: int = 3
     temperature: float = 0.2
     max_tokens: int = 4000
+    _model_index: int = field(init=False, default=0)
+    _request_counter: int = field(init=False, default=0)
 
     def __post_init__(self) -> None:
         if self.api_key is None:
             self.api_key = os.getenv("DASHSCOPE_API_KEY")
-        if self.model is None:
-            self.model = os.getenv("QWEN_MODEL", "qwen-plus")
+        if self.models is None:
+            self.models = [
+                "qwen-plus-2025-07-14",
+                "qwen-plus-2025-04-28",
+                "qwen-plus-2025-01-25",
+                "qwen-plus-1125",
+                "qwen-plus-1127",
+                "qwen-plus-1220",
+                "qwen-plus-0112",
+                "qwen-plus-0919",
+                "qwen-plus-0723",
+                "qwen-plus-0806",
+            ]
         dashscope.api_key = self.api_key
+
+    @property
+    def model(self) -> str:
+        return self.models[self._model_index]
+
+    def _rotate_model(self) -> None:
+        self._model_index += 1
+        if self._model_index >= len(self.models):
+            raise RuntimeError("All available models have been exhausted")
 
     def chat(self, messages: List[Dict[str, str]], *,
              temperature: Optional[float] = None,
@@ -56,8 +83,20 @@ class LLMClient:
                     input={"messages": messages},
                     parameters={"temperature": temperature, "max_tokens": max_tokens},
                 )
-                return response['output']['text']
-            except Exception as exc:  # pragma: no cover - network errors
+                self._request_counter += 1
+                if self._request_counter % 2 == 0:
+                    time.sleep(1)
+
+                if response.status_code == 200:
+                    return response.output.text
+                elif response.status_code == 400:
+                    self._rotate_model()
+                    continue
+                else:
+                    raise RuntimeError(
+                        f"Model call failed with status {response.status_code}: {response.message}"
+                    )
+            except Exception:
                 attempt += 1
                 if attempt >= self.max_retries:
                     raise


### PR DESCRIPTION
## Summary
- rotate through multiple Qwen Plus models and switch on HTTP 400 errors
- throttle DashScope calls by pausing one second after every two requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d7ec361d4832a8f78be0b060bd780