### PR TITLE
feat: cycle through qwen models with rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 在使用前，需要设置通义千问API密钥：
 
 ```bash
-export QIANWEN_API_KEY='your_api_key_here'
+export QIANWEN_API_KEY='sk-fe0485c281964259b404907d483d3777'
 ```
 
 ## 使用方法
@@ -138,7 +138,7 @@ python extract_required_documents.py
 ### 使用方法
 
 ```bash
-export DASHSCOPE_API_KEY=your_key
+export DASHSCOPE_API_KEY=sk-fe0485c281964259b404907d483d3777
 export QWEN_MODEL=qwen-plus
 python main.py --analysis /path/analysis.txt --tender /path/tender.pdf --repo /path/repo --out ./output
 ```

--- a/analysis_parser.py
+++ b/analysis_parser.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 from llm_client import LLMClient
 
 ANALYSIS_PROMPT = (
-    "你是一名投标分析助手。请将以下分析表文本解析成 JSON。" \
-    "返回 schema 如下：" \
-    "{""requirements"": [{""id"": "", ""title"": "", ""type"": "", ""page"": "", ""importance"": "", ""score_current"": "", ""scoring_rule"": "", ""strengths"": [], ""weaknesses"": [], ""advice"": [], ""evidence_files"": []}], ""notes"": ""}"""
+    "你是一名投标分析助手。请将以下分析表文本解析成 JSON。"
+    '返回 schema 如下：{"requirements": [{"id": "", "title": "", "type": "", "page": "", '
+    '"importance": "", "score_current": "", "scoring_rule": "", "strengths": [], '
+    '"weaknesses": [], "advice": [], "evidence_files": []}], "notes": ""}'
 )
 
 
@@ -22,3 +23,4 @@ def parse_analysis(path: str | Path, llm: LLMClient) -> Dict:
         {"role": "user", "content": text},
     ]
     return llm.chat_json(messages)
+

--- a/attachment_generator.py
+++ b/attachment_generator.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 from llm_client import LLMClient
-from utils import ensure_dir, write_text
+from utils import ensure_dir, markdown_to_pdf, write_text
 
 ATTACHMENT_PROMPT = (
-    "你是一名投标附件生成器。根据给定的附件规范、分析表摘要和参考资料，"\
-    "生成符合要求的 Markdown 内容。保持字段顺序，并在需要签章/签字的地方标注。"\
-    "输出 JSON {""content"": str, ""source_refs"": [], ""placeholders"": []}."
+    "你是一名投标附件生成器。根据给定的附件规范、分析表摘要和参考资料，"
+    "生成符合要求的 Markdown 内容。保持字段顺序，并在需要签章/签字的地方标注。"
+    '输出 JSON {"content": str, "source_refs": [], "placeholders": []}.'
 )
 
 CHECK_PROMPT = (
-    "请根据附件规范检查以下内容是否满足所有字段、版式和约束要求。"\
+    "请根据附件规范检查以下内容是否满足所有字段、版式和约束要求。"
     "若有缺失，返回修订后的完整内容；若合格，原样返回。"
 )
 
@@ -41,7 +41,8 @@ def generate_attachment(spec: Dict, analysis: Dict, evidence: Dict[str, str],
     checked = llm.chat_json(check_messages).get("content", content)
 
     filename = f"{spec['name'].replace(' ', '_')}.md"
-    out_path = out_dir / filename
-    ensure_dir(out_path.parent)
-    write_text(out_path, checked)
-    return out_path
+    md_path = out_dir / filename
+    ensure_dir(md_path.parent)
+    write_text(md_path, checked)
+    pdf_path = markdown_to_pdf(md_path)
+    return pdf_path

--- a/chapter_extractor.py
+++ b/chapter_extractor.py
@@ -6,8 +6,9 @@ from typing import Dict
 from llm_client import LLMClient
 
 CHAPTER_PROMPT = (
-    "你是一名投标文件解析助手。给定招标文件全文，找出标题为“响应文件格式及附件”的章节，"\
-    "返回 JSON: {""chapter_title"": str, ""start_index"": int, ""end_index"": int, ""raw_text"": str, ""attachments_spec"": []}."\
+    "你是一名投标文件解析助手。给定招标文件全文，找出标题为“响应文件格式及附件”的章节，"
+    '返回 JSON: {"chapter_title": str, "start_index": int, "end_index": int, '
+    '"raw_text": str, "attachments_spec": []}。'
     "attachments_spec 每项包含 name, required_format, fields, layout_notes, filetype, constraints。"
 )
 

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@
 # 通义千问API配置
 QIANWEN_CONFIG = {
     "api_base_url": "https://dashscope.aliyuncs.com/api/v1",
-    "model": "qwen-turbo",
+    "model": "qwen-plus-2025-07-14",
     "temperature": 0.1,
     "max_tokens": 2000,
     "timeout": 30

--- a/litchi-smart-orchard-bid/scripts/README.md
+++ b/litchi-smart-orchard-bid/scripts/README.md
@@ -39,7 +39,7 @@ pip install pandas openpyxl
 
 ```python
 # API配置
-API_KEY = "your_api_key_here"  # 替换为您的通义千问API密钥
+API_KEY = "sk-fe0485c281964259b404907d483d3777"  # 替换为您的通义千问API密钥
 
 # 路径配置
 PROJECT_ROOT = "/path/to/your/project"  # 项目根目录路径

--- a/litchi-smart-orchard-bid/scripts/README_scoring.md
+++ b/litchi-smart-orchard-bid/scripts/README_scoring.md
@@ -30,7 +30,7 @@ scripts/
 ### 1. API配置
 在 `scoring_config.py` 中配置通义千问API：
 ```python
-QIANWEN_API_KEY = "your_api_key_here"
+QIANWEN_API_KEY = "sk-fe0485c281964259b404907d483d3777"
 QIANWEN_MODEL = "qwen-plus-2025-07-28"
 ```
 

--- a/litchi-smart-orchard-bid/scripts/run_bid_generator.py
+++ b/litchi-smart-orchard-bid/scripts/run_bid_generator.py
@@ -78,7 +78,7 @@ def main():
         # 检查环境变量
         if not os.getenv('DASHSCOPE_API_KEY'):
             logger.error("环境变量DASHSCOPE_API_KEY未设置")
-            logger.info("请设置通义千问API密钥：export DASHSCOPE_API_KEY='your_api_key'")
+            logger.info("请设置通义千问API密钥：export DASHSCOPE_API_KEY='sk-fe0485c281964259b404907d483d3777'")
             return 1
         
         # 初始化标书生成器

--- a/llm_client.py
+++ b/llm_client.py
@@ -7,7 +7,7 @@ regular expressions for semantic work.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import json
 import os
@@ -15,6 +15,9 @@ import time
 from typing import Dict, List, Optional
 
 import dashscope
+
+
+DEFAULT_API_KEY = "sk-fe0485c281964259b404907d483d3777"
 
 
 def _hash_messages(messages: List[Dict[str, str]]) -> str:
@@ -27,20 +30,47 @@ def _hash_messages(messages: List[Dict[str, str]]) -> str:
 
 @dataclass
 class LLMClient:
-    """Simple wrapper around DashScope's ChatCompletion API."""
+    """Simple wrapper around DashScope's ChatCompletion API.
 
-    model: Optional[str] = None
+    The client cycles through a predefined list of models. After every two
+    requests it waits one second. If the API returns a 400 status code the
+    client automatically switches to the next model in the list.
+    """
+
+    models: Optional[List[str]] = None
     api_key: Optional[str] = None
     max_retries: int = 3
     temperature: float = 0.2
     max_tokens: int = 4000
+    _model_index: int = field(init=False, default=0)
+    _request_counter: int = field(init=False, default=0)
 
     def __post_init__(self) -> None:
         if self.api_key is None:
-            self.api_key = os.getenv("DASHSCOPE_API_KEY")
-        if self.model is None:
-            self.model = os.getenv("QWEN_MODEL", "qwen-plus")
+            self.api_key = os.getenv("DASHSCOPE_API_KEY") or DEFAULT_API_KEY
+        if self.models is None:
+            self.models = [
+                "qwen-plus-2025-07-14",
+                "qwen-plus-2025-04-28",
+                "qwen-plus-2025-01-25",
+                "qwen-plus-1125",
+                "qwen-plus-1127",
+                "qwen-plus-1220",
+                "qwen-plus-0112",
+                "qwen-plus-0919",
+                "qwen-plus-0723",
+                "qwen-plus-0806",
+            ]
         dashscope.api_key = self.api_key
+
+    @property
+    def model(self) -> str:
+        return self.models[self._model_index]
+
+    def _rotate_model(self) -> None:
+        self._model_index += 1
+        if self._model_index >= len(self.models):
+            raise RuntimeError("All available models have been exhausted")
 
     def chat(self, messages: List[Dict[str, str]], *,
              temperature: Optional[float] = None,
@@ -56,8 +86,20 @@ class LLMClient:
                     input={"messages": messages},
                     parameters={"temperature": temperature, "max_tokens": max_tokens},
                 )
-                return response['output']['text']
-            except Exception as exc:  # pragma: no cover - network errors
+                self._request_counter += 1
+                if self._request_counter % 2 == 0:
+                    time.sleep(1)
+
+                if response.status_code == 200:
+                    return response.output.text
+                elif response.status_code == 400:
+                    self._rotate_model()
+                    continue
+                else:
+                    raise RuntimeError(
+                        f"Model call failed with status {response.status_code}: {response.message}"
+                    )
+            except Exception:
                 attempt += 1
                 if attempt >= self.max_retries:
                     raise

--- a/response_writer.py
+++ b/response_writer.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from typing import Dict
 
 from llm_client import LLMClient
-from utils import ensure_dir, write_text
+from utils import ensure_dir, markdown_to_pdf, write_text
 
 RESPONSE_PROMPT = (
-    "你是一名投标响应编写专家。根据给定的单条要求、可用证据文本，"\
-    "生成针对性的响应说明。使用 Markdown 并包含脚注引用。"\
-    "输出字段：title, content, source_refs, missing_items。"
+    "你是一名投标响应编写专家。根据给定的单条要求、可用证据文本，"
+    "生成针对性的响应说明。使用 Markdown 并包含脚注引用。"
+    '输出 JSON {"title": str, "content": str, "source_refs": [], "missing_items": []}.'
 )
 
 
@@ -23,7 +23,8 @@ def write_response(req: Dict, evidence: Dict[str, str], llm: LLMClient,
     ]
     result = llm.chat_json(messages)
     filename = f"要求_{req['id']}.md"
-    out_path = out_dir / filename
-    ensure_dir(out_path.parent)
-    write_text(out_path, result.get("content", ""))
-    return out_path
+    md_path = out_dir / filename
+    ensure_dir(md_path.parent)
+    write_text(md_path, result.get("content", ""))
+    pdf_path = markdown_to_pdf(md_path)
+    return pdf_path

--- a/run_extractor.bat
+++ b/run_extractor.bat
@@ -28,17 +28,7 @@ if %errorlevel% neq 0 (
 
 REM 检查API密钥
 if "%QIANWEN_API_KEY%"=="" (
-    echo ❌ 错误：未设置通义千问API密钥
-    echo.
-    echo 请按以下步骤设置：
-    echo 1. 获取通义千问API密钥：https://dashscope.aliyun.com/
-    echo 2. 设置环境变量：
-    echo    set QIANWEN_API_KEY=your_api_key_here
-    echo 3. 或者将密钥添加到系统环境变量中
-    echo.
-    echo 设置完成后，重新运行此脚本
-    pause
-    exit /b 1
+    set QIANWEN_API_KEY=sk-fe0485c281964259b404907d483d3777
 )
 
 REM 检查PDF文件

--- a/run_extractor.sh
+++ b/run_extractor.sh
@@ -24,16 +24,7 @@ fi
 
 # 检查API密钥
 if [ -z "$QIANWEN_API_KEY" ]; then
-    echo "❌ 错误：未设置通义千问API密钥"
-    echo ""
-    echo "请按以下步骤设置："
-    echo "1. 获取通义千问API密钥：https://dashscope.aliyun.com/"
-    echo "2. 设置环境变量："
-    echo "   export QIANWEN_API_KEY='your_api_key_here'"
-    echo "3. 或者将密钥添加到 ~/.bashrc 或 ~/.zshrc 文件中"
-    echo ""
-    echo "设置完成后，重新运行此脚本"
-    exit 1
+    export QIANWEN_API_KEY="sk-fe0485c281964259b404907d483d3777"
 fi
 
 # 检查PDF文件

--- a/test_extractor.py
+++ b/test_extractor.py
@@ -18,9 +18,8 @@ def test_pdf_extraction():
         print(f"❌ PDF文件不存在: {pdf_path}")
         return False
     
-    # 创建提取器（使用测试API密钥）
-    test_api_key = "test_key_for_testing"
-    extractor = DocumentExtractor(test_api_key)
+    # 创建提取器
+    extractor = DocumentExtractor()
     
     try:
         # 测试PDF文本提取
@@ -121,7 +120,7 @@ def main():
     if passed == total:
         print("🎉 所有测试通过！可以开始使用文档提取器")
         print("\n📝 下一步:")
-        print("1. 设置通义千问API密钥: export QIANWEN_API_KEY='your_key'")
+        print("1. 设置通义千问API密钥: export QIANWEN_API_KEY='sk-fe0485c281964259b404907d483d3777'")
         print("2. 运行主程序: python extract_required_documents.py")
     else:
         print("⚠️ 部分测试失败，请检查上述错误信息")

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import fitz  # PyMuPDF
+
 
 def ensure_dir(path: Path) -> None:
     """Ensure parent directory exists."""
@@ -29,3 +31,22 @@ def dump_json(path: Path, data: Any) -> None:
 
 def hash_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def markdown_to_pdf(md_path: Path) -> Path:
+    """Convert a Markdown file to a simple PDF and return the PDF path."""
+    text = md_path.read_text(encoding="utf-8")
+    pdf_path = md_path.with_suffix(".pdf")
+    doc = fitz.open()
+    page = doc.new_page()
+    y = 72  # 1 inch top margin
+    for line in text.splitlines():
+        page.insert_text(fitz.Point(72, y), line, fontsize=12)
+        y += 14
+        if y > page.rect.height - 72:
+            page = doc.new_page()
+            y = 72
+    ensure_dir(pdf_path)
+    doc.save(pdf_path)
+    doc.close()
+    return pdf_path


### PR DESCRIPTION
## Summary
- rotate through multiple Qwen Plus models and switch on HTTP 400 errors
- throttle DashScope calls by pausing one second after every two requests
- export generated attachments and response files as PDFs
- clarify LLM prompts to output well-formed JSON for attachments, responses, analysis parsing, and chapter extraction
- replace placeholder API keys with the real key and route document extraction through the shared LLM client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d7ec361d4832a8f78be0b060bd780