### PR TITLE
feat: add LLM-driven PDF build pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# 环境变量示例
+DASHSCOPE_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+build/
+*.pdf

--- a/README.md
+++ b/README.md
@@ -151,3 +151,22 @@ python main.py --analysis /path/analysis.txt --tender /path/tender.pdf --repo /p
 - `logs/`：关键日志
 
 所有文本理解与生成均通过通义千问API完成，本地代码仅负责I/O与调度。
+
+## 新增：基于需求列表构建 PDF
+
+本项目新增 `build_pdf` 管线，可将需求列表与知识库整合成单个 PDF。示例：
+
+```bash
+python -m build_pdf --requirements examples/reqs.json --kb ./kb --out build/output.pdf
+```
+
+参数说明：
+- `--requirements` 需求列表文件，支持 JSON/CSV/Markdown 表格
+- `--kb` 知识库目录
+- `--out` 输出 PDF 路径
+- `--latex-template` 自定义 LaTeX 模板，可选
+- `--workdir` 工作目录，默认 `./build`
+- `--topk` 每条需求检索候选数量，默认 5
+- `--use-llm` 是否启用 LLM 处理，默认 `true`
+
+生成文件包括：`merged.md`、`main.tex`、`meta.json`、`logs/build.log`。

--- a/build_pdf.py
+++ b/build_pdf.py
@@ -1,0 +1,4 @@
+from src.pdf_builder import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "build-pdf-pipeline"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "dashscope",
+]
+
+[tool.build_pdf]
+model = "qwen-plus-2025-07-14"
+temperature = 0.2
+topk = 5
+cache_dir = "cache"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.31.0
 python-docx==0.8.11
 dashscope==1.14.1
 python-dotenv==1.0.1
+pytest==8.1.1

--- a/src/build_pdf.py
+++ b/src/build_pdf.py
@@ -1,0 +1,4 @@
+from .pdf_builder import main
+
+if __name__ == "__main__":
+    main()

--- a/src/caching.py
+++ b/src/caching.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Simple local cache for LLM calls to avoid repeated charges."""
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, List
+import logging
+
+from llm_client import LLMClient as Client  # alias as Client per instructions
+
+
+class LLMCache:
+    """Disk-based cache for LLM requests."""
+
+    def __init__(self, cache_dir: Path) -> None:
+        self.cache_dir = cache_dir
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _key(self, messages: List[Dict[str, str]]) -> str:
+        m = hashlib.sha256()
+        for msg in messages:
+            m.update(json.dumps(msg, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+        return m.hexdigest()
+
+    def get(self, messages: List[Dict[str, str]]) -> str | None:
+        key = self._key(messages)
+        path = self.cache_dir / f"{key}.json"
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        return None
+
+    def set(self, messages: List[Dict[str, str]], value: str) -> None:
+        key = self._key(messages)
+        path = self.cache_dir / f"{key}.json"
+        path.write_text(value, encoding="utf-8")
+
+
+def llm_json(client: Client, system: str, user: str, cache: LLMCache, *, logger: logging.Logger | None = None) -> Dict:
+    """Call LLM with caching and expect a JSON response."""
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    if logger:
+        import inspect
+        logger.debug("LLMClient.chat signature: %s", inspect.signature(client.chat))
+    cached = cache.get(messages)
+    if cached is not None:
+        return json.loads(cached)
+    text = client.chat(messages)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        # attempt one more repair call
+        repair_user = f"The previous response was not valid JSON: {text}. Please return valid JSON only."
+        text = client.chat([
+            {"role": "system", "content": system},
+            {"role": "user", "content": repair_user},
+        ])
+        data = json.loads(text)
+    cache.set(messages, json.dumps(data, ensure_ascii=False))
+    return data
+
+
+def llm_rewrite(client: Client, system: str, user: str, cache: LLMCache) -> str:
+    """Call LLM with caching for text generation or rewriting."""
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    cached = cache.get(messages)
+    if cached is not None:
+        return cached
+    text = client.chat(messages)
+    cache.set(messages, text)
+    return text

--- a/src/content_merge.py
+++ b/src/content_merge.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Merge selected knowledge base snippets into unified Markdown."""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from llm_client import LLMClient as Client
+from .caching import LLMCache, llm_rewrite
+from .requirements_parser import RequirementItem
+
+
+def merge_contents(requirements: List[RequirementItem], ranked: Dict[str, List[Tuple[Path, float]]], *, client: Client, cache: LLMCache, use_llm: bool = True) -> tuple[str, Dict]:
+    """Merge contents for requirements.
+
+    Returns merged Markdown text and metadata mapping.
+    """
+    sections: List[str] = []
+    meta: Dict[str, Dict] = {}
+    for req in requirements:
+        files = ranked.get(req.id, [])
+        meta_item = {"title": req.title, "candidates": []}
+        snippets: List[str] = []
+        for path, score in files:
+            meta_item["candidates"].append({"path": str(path), "score": score})
+            try:
+                snippets.append(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+        if not snippets:
+            placeholder = f"未找到与需求 {req.title} 相关的内容。"
+            sections.append(f"### {req.title}\n\n{placeholder}\n")
+            meta_item["selected"] = None
+        else:
+            if use_llm:
+                system = (
+                    "Combine the following content pieces into a coherent Markdown section. "
+                    "Remove duplicates but keep footnotes referencing original file paths."
+                )
+                user_parts = []
+                for (path, _), snippet in zip(files, snippets):
+                    user_parts.append(f"Source: {path}\n{snippet}")
+                user = f"Requirement: {req.title}\n\n" + "\n\n".join(user_parts)
+                merged = llm_rewrite(client, system, user, cache)
+            else:
+                merged = "\n\n".join(snippets)
+            sections.append(f"### {req.title}\n\n{merged}\n")
+            meta_item["selected"] = [str(p) for p, _ in files]
+        meta[req.id] = meta_item
+    merged_markdown = "\n".join(sections)
+    return merged_markdown, meta

--- a/src/kb_search.py
+++ b/src/kb_search.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Knowledge base scanning and LLM-based ranking."""
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from llm_client import LLMClient as Client
+from .caching import LLMCache, llm_json
+from .requirements_parser import RequirementItem
+
+
+def scan_kb(kb_dir: Path) -> List[Path]:
+    """Return all files under ``kb_dir``."""
+    return [p for p in kb_dir.rglob('*') if p.is_file()]
+
+
+def rank_files(requirement: RequirementItem, files: List[Path], *, topk: int, client: Client, cache: LLMCache, use_llm: bool = True) -> List[Tuple[Path, float]]:
+    """Score and rank files for a requirement."""
+    scores: List[Tuple[Path, float]] = []
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        snippet = text[:800]
+        if use_llm:
+            system = (
+                "Given a requirement and a file snippet, score the relevance between 0 and 1 "
+                "and return JSON {\"score\": float}."
+            )
+            user = (
+                f"Requirement: {requirement.title}\nKeywords: {', '.join(requirement.keywords)}\n"
+                f"File: {path.name}\nSnippet:\n{snippet}"
+            )
+            data = llm_json(client, system, user, cache)
+            score = float(data.get("score", 0.0))
+        else:
+            lower = (path.name + snippet).lower()
+            score = sum(1 for kw in requirement.keywords if kw.lower() in lower)
+        scores.append((path, score))
+    scores.sort(key=lambda x: x[1], reverse=True)
+    return scores[:topk]

--- a/src/latex_renderer.py
+++ b/src/latex_renderer.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Rendering utilities: Markdown → LaTeX and template filling."""
+
+from pathlib import Path
+
+from llm_client import LLMClient as Client
+from .caching import LLMCache, llm_rewrite
+
+
+def markdown_to_latex(markdown: str, *, client: Client, cache: LLMCache, use_llm: bool = True) -> str:
+    """Convert Markdown text to LaTeX."""
+    if use_llm:
+        system = "Convert the following Markdown into LaTeX code only."
+        latex = llm_rewrite(client, system, markdown, cache)
+    else:
+        latex = "\\begin{verbatim}\n" + markdown + "\n\\end{verbatim}\n"
+    return latex
+
+
+def render_main_tex(body: str, template_path: Path, output_path: Path) -> str:
+    """Fill the LaTeX template with body content."""
+    template = template_path.read_text(encoding="utf-8")
+    tex = template.replace("%%CONTENT%%", body)
+    output_path.write_text(tex, encoding="utf-8")
+    return tex

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utility helpers for unified logging configuration."""
+
+import logging
+from pathlib import Path
+
+
+def get_logger(name: str, workdir: Path) -> logging.Logger:
+    """Return a logger that writes to ``workdir/logs`` and stdout.
+
+    Parameters
+    ----------
+    name:
+        Logger name.
+    workdir:
+        Base working directory. Log file will be created under
+        ``workdir / "logs" / "build.log"``.
+    """
+    logs_dir = workdir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / "build.log"
+
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.DEBUG)
+
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(fmt)
+    file_handler.setLevel(logging.DEBUG)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(fmt)
+    stream_handler.setLevel(logging.INFO)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+    return logger

--- a/src/pdf_builder.py
+++ b/src/pdf_builder.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Orchestrate end-to-end build from requirements to PDF."""
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+import logging
+import tomllib
+
+from llm_client import LLMClient as Client
+from .logging_utils import get_logger
+from .caching import LLMCache
+from .requirements_parser import parse_requirements
+from .kb_search import scan_kb, rank_files
+from .content_merge import merge_contents
+from .latex_renderer import markdown_to_latex, render_main_tex
+
+
+DEFAULT_TEMPLATE = Path("templates/main.tex")
+
+
+def load_config() -> Dict:
+    path = Path("pyproject.toml")
+    if path.exists():
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        return data.get("tool", {}).get("build_pdf", {})
+    return {}
+
+
+def build_pdf(requirements: Path, kb: Path, out: Path, *, latex_template: Path | None = None, workdir: Path | None = None, topk: int = 5, use_llm: bool = True) -> None:
+    """Main pipeline to build PDF."""
+    workdir = workdir or Path("build")
+    workdir.mkdir(parents=True, exist_ok=True)
+    logger = get_logger("build_pdf", workdir)
+    cache = LLMCache(workdir / "cache")
+    config = load_config()
+    model = config.get("model")
+    temperature = config.get("temperature")
+    client = Client(models=[model] if model else None, temperature=temperature if temperature is not None else 0.2)
+    import inspect
+    logger.debug("LLMClient.chat signature: %s", inspect.signature(client.chat))
+    logger.debug("LLMClient.chat_json signature: %s", inspect.signature(client.chat_json))
+
+    requirements_items = parse_requirements(requirements, client=client, cache=cache, use_llm=use_llm)
+    files = scan_kb(kb)
+    ranked: Dict[str, List] = {}
+    for item in requirements_items:
+        ranked[item.id] = rank_files(item, files, topk=topk, client=client, cache=cache, use_llm=use_llm)
+    merged_md, meta = merge_contents(requirements_items, ranked, client=client, cache=cache, use_llm=use_llm)
+    merged_md_path = workdir / "merged.md"
+    merged_md_path.write_text(merged_md, encoding="utf-8")
+
+    latex_body = markdown_to_latex(merged_md, client=client, cache=cache, use_llm=use_llm)
+    template = latex_template or DEFAULT_TEMPLATE
+    tex_path = workdir / "main.tex"
+    render_main_tex(latex_body, template, tex_path)
+
+    meta_path = workdir / "meta.json"
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    compile_pdf(tex_path, out, logger)
+
+
+def compile_pdf(tex_path: Path, out_pdf: Path, logger: logging.Logger) -> None:
+    """Compile LaTeX into PDF using latexmk or xelatex."""
+    workdir = tex_path.parent
+    cmd = ["latexmk", "-xelatex", "-interaction=nonstopmode", tex_path.name]
+    try:
+        subprocess.run(cmd, cwd=workdir, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.run(cmd, cwd=workdir, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        built_pdf = workdir / (tex_path.stem + ".pdf")
+        out_pdf.parent.mkdir(parents=True, exist_ok=True)
+        built_pdf.rename(out_pdf)
+    except FileNotFoundError:
+        logger.error("latexmk not found; please install TeX distribution")
+    except subprocess.CalledProcessError as exc:
+        logger.error("LaTeX compilation failed: %s", exc.stdout.decode("utf-8", errors="ignore"))
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build PDF from requirements and knowledge base")
+    parser.add_argument("--requirements", type=Path, required=True)
+    parser.add_argument("--kb", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--latex-template", type=Path, default=None)
+    parser.add_argument("--workdir", type=Path, default=Path("build"))
+    parser.add_argument("--topk", type=int, default=5)
+    parser.add_argument("--use-llm", type=str, default="true")
+
+    args = parser.parse_args()
+    use_llm = args.use_llm.lower() == "true"
+    build_pdf(args.requirements, args.kb, args.out, latex_template=args.latex_template, workdir=args.workdir, topk=args.topk, use_llm=use_llm)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/requirements_parser.py
+++ b/src/requirements_parser.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Parse requirement lists into a unified structure using LLM."""
+
+import json
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from llm_client import LLMClient as Client
+from .caching import LLMCache, llm_json
+
+
+@dataclass
+class RequirementItem:
+    """Standard requirement item."""
+
+    id: str
+    title: str
+    keywords: List[str]
+    source: str
+    notes: str
+    weight: float
+
+
+def _from_dict(data: dict, index: int) -> RequirementItem:
+    keywords = data.get("keywords", [])
+    if isinstance(keywords, str):
+        keywords = [k.strip() for k in keywords.split(',') if k.strip()]
+    return RequirementItem(
+        id=str(data.get("id", index + 1)),
+        title=str(data.get("title", "")),
+        keywords=keywords,
+        source=str(data.get("source", "")),
+        notes=str(data.get("notes", "")),
+        weight=float(data.get("weight", 1.0)),
+    )
+
+
+def parse_requirements(path: Path, *, client: Client, cache: LLMCache, use_llm: bool = True) -> List[RequirementItem]:
+    """Parse the requirement file into :class:`RequirementItem` objects."""
+    text = path.read_text(encoding="utf-8")
+    if use_llm:
+        system = (
+            "You convert requirement lists provided in JSON/CSV/Markdown into a JSON array "
+            "of objects with fields id,title,keywords,source,notes,weight. keywords is a list of strings."
+        )
+        user = f"Input content:\n{text}\nReturn JSON array only."
+        data = llm_json(client, system, user, cache)
+        items_raw = data if isinstance(data, list) else data.get("items", [])
+    else:
+        if path.suffix.lower() == ".json":
+            items_raw = json.loads(text)
+        elif path.suffix.lower() == ".csv":
+            reader = csv.DictReader(text.splitlines())
+            items_raw = list(reader)
+        else:
+            lines = [line for line in text.splitlines() if line.strip()]
+            headers = [h.strip() for h in lines[0].split('|') if h.strip()]
+            items_raw = []
+            for line in lines[2:]:
+                parts = [p.strip() for p in line.split('|') if p.strip()]
+                item = {headers[i]: parts[i] for i in range(min(len(headers), len(parts)))}
+                items_raw.append(item)
+    items = [_from_dict(d, i) for i, d in enumerate(items_raw)]
+    return items

--- a/templates/main.tex
+++ b/templates/main.tex
@@ -1,0 +1,17 @@
+\documentclass{ctexart}
+\usepackage{geometry}
+\usepackage{hyperref}
+\usepackage{graphicx}
+\usepackage{listings}
+\usepackage{xcolor}
+\geometry{a4paper, margin=1in}
+\title{自动化生成文档}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+\tableofcontents
+\newpage
+%%CONTENT%%
+\end{document}

--- a/tests/test_kb_search.py
+++ b/tests/test_kb_search.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from src.kb_search import rank_files
+from src.caching import LLMCache
+from src.requirements_parser import RequirementItem
+
+
+class DummyClient:
+    pass
+
+
+def fake_llm_json(client, system, user, cache):
+    if "file1" in user:
+        return {"score": 0.9}
+    return {"score": 0.1}
+
+
+def test_rank_files(monkeypatch, tmp_path):
+    f1 = tmp_path / "file1.txt"
+    f1.write_text("hello", encoding="utf-8")
+    f2 = tmp_path / "file2.txt"
+    f2.write_text("world", encoding="utf-8")
+    req = RequirementItem(id="1", title="t", keywords=["hello"], source="", notes="", weight=1)
+    from src import kb_search as ks
+    monkeypatch.setattr(ks, "llm_json", fake_llm_json)
+    ranked = rank_files(req, [f1, f2], topk=2, client=DummyClient(), cache=LLMCache(tmp_path / "cache"), use_llm=True)
+    assert ranked[0][0] == f1

--- a/tests/test_latex_renderer.py
+++ b/tests/test_latex_renderer.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from src.latex_renderer import markdown_to_latex, render_main_tex
+from src.caching import LLMCache
+
+
+class DummyClient:
+    def chat(self, messages, temperature=None, max_tokens=None):
+        return "LaTeX"
+
+
+def test_render(tmp_path):
+    cache = LLMCache(tmp_path / "cache")
+    md = "# Title"
+    latex = markdown_to_latex(md, client=DummyClient(), cache=cache, use_llm=False)
+    template = Path("templates/main.tex")
+    out = tmp_path / "main.tex"
+    render_main_tex(latex, template, out)
+    assert out.read_text(encoding="utf-8").strip() != ""

--- a/tests/test_requirements_parser.py
+++ b/tests/test_requirements_parser.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from src.requirements_parser import parse_requirements
+from src.caching import LLMCache
+
+
+class DummyClient:
+    def chat(self, messages, temperature=None, max_tokens=None):
+        return '[{"id": "1", "title": "测试", "keywords": ["k"], "source": "", "notes": "", "weight": 1}]'
+
+
+def test_parse_requirements_llm(tmp_path):
+    req_file = tmp_path / "req.md"
+    req_file.write_text("|id|title|\n|--|--|\n|1|a|", encoding="utf-8")
+    items = parse_requirements(req_file, client=DummyClient(), cache=LLMCache(tmp_path / "cache"), use_llm=True)
+    assert items[0].title == "测试"


### PR DESCRIPTION
## Summary
- add modular pipeline to parse requirements, search knowledge base, merge content, convert to LaTeX and compile PDF
- provide CLI `python -m build_pdf` with caching, logging and LaTeX template
- include minimal unit tests for parsing, ranking and rendering

## Testing
- `python -m pytest tests/test_requirements_parser.py tests/test_kb_search.py tests/test_latex_renderer.py -q`
- `python -m build_pdf --help`


------
https://chatgpt.com/codex/tasks/task_e_689e94544404832ab24e8799ed0355c0